### PR TITLE
Bundle Python backend into Electron app for Windows distribution

### DIFF
--- a/axolotlmeasurement/electron-builder.yml
+++ b/axolotlmeasurement/electron-builder.yml
@@ -1,5 +1,5 @@
-appId: com.electron.app
-productName: axolotlmeasurement
+appId: T.Work.InvestigatingAxolotls
+productName: InvestigatingAxolotls
 directories:
   buildResources: build
 files:
@@ -13,33 +13,17 @@ asarUnpack:
   - resources/**
 extraResources:
   - from: resources
-  - to: resources
+    to: resources
 win:
-  executableName: axolotlmeasurement
+  executableName: InvestigatingAxolotls
+  target:
+    - nsis
+    - zip
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
-mac:
-  entitlementsInherit: build/entitlements.mac.plist
-  extendInfo:
-    - NSCameraUsageDescription: Application requests access to the device's camera.
-    - NSMicrophoneUsageDescription: Application requests access to the device's microphone.
-    - NSDocumentsFolderUsageDescription: Application requests access to the user's Documents folder.
-    - NSDownloadsFolderUsageDescription: Application requests access to the user's Downloads folder.
-  notarize: false
-dmg:
-  artifactName: ${name}-${version}.${ext}
-linux:
-  target:
-    - AppImage
-    - snap
-    - deb
-  maintainer: electronjs.org
-  category: Utility
-appImage:
-  artifactName: ${name}-${version}.${ext}
 npmRebuild: false
 publish:
   provider: generic

--- a/axolotlmeasurement/package-lock.json
+++ b/axolotlmeasurement/package-lock.json
@@ -18,7 +18,6 @@
         "electron-updater": "^6.3.9",
         "node-fetch": "^2.7.0",
         "pinia": "^3.0.3",
-        "python": "^0.0.4",
         "vue-router": "^4.5.1"
       },
       "devDependencies": {
@@ -7752,14 +7751,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/python": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/python/-/python-0.0.4.tgz",
-      "integrity": "sha512-7avKA/6XxrwcGSDes8xGn7FHAUdAUQXKHtpjDulyv5/nm7TcPblmPRvXjjwx5knWHqeRiipqH/TZR2HhmJ4CGQ==",
-      "engines": {
-        "node": ">= 0.4.1"
       }
     },
     "node_modules/queue-microtask": {

--- a/axolotlmeasurement/package.json
+++ b/axolotlmeasurement/package.json
@@ -23,32 +23,6 @@
     "build:linux": "npm run build && electron-builder --linux",
     "dist": "electron-builder"
   },
-  "build": {
-    "appId": "T.Work.InvestigatingAxolotls",
-    "productName": "InvestigatingAxolotls",
-    "directories": {
-      "output": "dist"
-    },
-    "win": {
-      "target": [
-        "nsis",
-        "zip"
-      ]
-    },
-    "mac": {
-      "category": "your.app.category.type"
-    },
-    "linux": {
-      "target": [
-        "AppImage",
-        "deb"
-      ]
-    },
-    "files": [
-      "**/*",
-      "!dist/**/*"
-    ]
-  },
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.1",
     "@electron-toolkit/utils": "^4.0.0",
@@ -59,7 +33,6 @@
     "electron-updater": "^6.3.9",
     "node-fetch": "^2.7.0",
     "pinia": "^3.0.3",
-    "python": "^0.0.4",
     "vue-router": "^4.5.1"
   },
   "devDependencies": {

--- a/axolotlmeasurement/src/backend/kp_est_01_results.py
+++ b/axolotlmeasurement/src/backend/kp_est_01_results.py
@@ -17,47 +17,50 @@ def resource_path(relative_path):
 
     return os.path.join(base_path, relative_path)
 
-# --- Path Refactoring ---
-model_path = resource_path("best.pt")
 
-# --- Initialize YOLO model ---
-model = YOLO(model_path)
+def process_images(image_paths: list) -> list:
+    """
+    Process a list of image file paths through the YOLO model.
+    Returns a list of dicts with image_name, bounding_box, and keypoints.
+    """
+    model_path = resource_path("best.pt")
+    model = YOLO(model_path)
 
-# --- Handling Input/Output ---
-if len(sys.argv) < 2:
-    # Print usage instructions to stderr
-    print("Usage: python kp_est_01_results.py <image_path_1> <image_path_2> ...", file=sys.stderr)
-    sys.exit(1)
+    all_results = []
+    for i, img_path_str in enumerate(image_paths, 1):
+        image_path = Path(img_path_str)
+        try:
+            # printing to stderr so I don't accidentally read in my program, because of how this file is set up.
+            print(f"Processing {i}/{len(image_paths)}: {image_path.name}", file=sys.stderr)
 
-image_files = [Path(p) for p in sys.argv[1:]]
+            results = model.predict(str(image_path), conf=0.25)
 
-# printing to stderr so I don't accidentally read in my program, because of how this file is set up.
-print(f"Found {len(image_files)} images to process...", file=sys.stderr)
+            for result in results:
+                if result.boxes and result.keypoints:
+                    image_data = {
+                        "image_name": image_path.name,
+                        "bounding_box": result.boxes.xyxy.tolist(),
+                        "keypoints": result.keypoints.xy.tolist()
+                    }
+                    all_results.append(image_data)
 
-all_results = []
-for i, image_path in enumerate(image_files, 1):
-    try:
-        print(f"Processing {i}/{len(image_files)}: {image_path.name}", file=sys.stderr)
+        except Exception as e:
+            # Errors go to stderr, since my program reads stdout for data
+            print(f"Error processing {image_path.name}: {str(e)}", file=sys.stderr)
+            continue
 
-        results = model.predict(str(image_path), conf=0.25)
+    # changed to stderr so that it wouldn't be included in std output
+    print(f"Processing complete!", file=sys.stderr)
+    return all_results
 
-        for result in results:
-            if result.boxes and result.keypoints:
-                image_data = {
-                    "image_name": image_path.name,
-                    "bounding_box": result.boxes.xyxy.tolist(),
-                    "keypoints": result.keypoints.xy.tolist()
-                }
-                all_results.append(image_data)
 
-    except Exception as e:
-        # Errors go to stderr, since my program reads stdout for data
-        print(f"Error processing {image_path.name}: {str(e)}", file=sys.stderr)
-        continue
+# Keep CLI usage for standalone testing/debugging
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python kp_est_01_results.py <image_path_1> <image_path_2> ...", file=sys.stderr)
+        sys.exit(1)
 
-# --- Final Output ---
-# i'm using this in main.py to read the results of this script, so important not to print anything else out to stdout!!!
-print(json.dumps(all_results))
-
-# changed to stderr so that it wouldn't be included in std output
-print(f"Processing complete!", file=sys.stderr)
+    print(f"Found {len(sys.argv) - 1} images to process...", file=sys.stderr)
+    results = process_images(sys.argv[1:])
+    # i'm using this in main.py to read the results of this script, so important not to print anything else out to stdout!!!
+    print(json.dumps(results))

--- a/axolotlmeasurement/src/main/jsonStorage.ts
+++ b/axolotlmeasurement/src/main/jsonStorage.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron'
 import { join } from 'path'
 import { promises as fs } from 'fs'
-import { ImageFile, Keypoint } from '../types'
+import { ImageFile } from '../types'
 
 interface ImageDatabase {
   version: number
@@ -108,21 +108,6 @@ export class JsonImageStorage {
         await this.save(this.cache)
       }
     }, 500) // Wait 500ms after last change before saving
-  }
-
-  /**
-   * This function can be deleted, remnant of a troubled past for my database
-   */
-  private normalizeKeypoints(keypoints: Keypoint[]): Keypoint[] {
-    if (!keypoints) {
-      // console.log('[JSON storage] No keypoints exist for this image') // clogs up console but useful
-      return []
-    }
-
-    // If it's already in the correct format (array of {name, x, y})
-    if (Array.isArray(keypoints) && keypoints[0]?.name !== undefined) {
-      return keypoints
-    } else return []
   }
 
   async getAllImages(): Promise<ImageFile[]> {


### PR DESCRIPTION
- Refactor kp_est_01_results.py into importable process_images() function
- Replace subprocess.run call in main.py with direct import
- Add uvicorn.run() entrypoint so PyInstaller exe starts the server
- Add backend spawn/kill lifecycle to index.ts (production mode only)
- Fix electron-builder.yml extraResources syntax and consolidate config
- Remove conflicting build section and dummy python dep from package.json
- Remove unused normalizeKeypoints function from jsonStorage.ts