### PR TITLE
Add multi-model switching with model stamping on exported images

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,77 @@
+# CLAUDE.md
+
+## Project Overview
+
+Electron desktop app for analyzing and measuring axolotl images using machine learning. A Vue 3 + TypeScript frontend sends images to a Python FastAPI backend running a YOLOv8 model to detect anatomical keypoints and bounding boxes.
+
+## Tech Stack
+
+- **Frontend**: Vue 3, TypeScript, Pinia, Vue Router, Vite
+- **Desktop**: Electron 35, electron-vite, electron-builder
+- **Backend**: Python 3, FastAPI, Uvicorn, Ultralytics (YOLOv8)
+- **Storage**: JSON-based file storage (jsonStorage.ts)
+
+## Project Structure
+
+```
+axolotlmeasurement/
+├── src/
+│   ├── backend/        # Python FastAPI server (main.py, ML model)
+│   ├── main/           # Electron main process (index.ts, jsonStorage.ts)
+│   ├── preload/        # Electron preload / IPC bridge
+│   ├── renderer/src/   # Vue 3 app
+│   │   ├── components/ # Reusable components (Header, KeypointDisplay)
+│   │   ├── views/      # Page views (InputView, ValidateView, GalleryView)
+│   │   ├── stores/     # Pinia stores (imageStore)
+│   │   └── router/     # Vue Router config
+│   └── types.ts        # Shared TypeScript interfaces
+├── build/              # Build resources (icons, certificates)
+└── resources/          # App resources
+```
+
+## Commands
+
+```bash
+# Install dependencies
+npm install
+
+# Run dev (start backend first, then Electron)
+npm run start-backend       # Windows
+npm run start-backend-mac   # macOS
+npm run dev                 # Electron + Vue dev server
+
+# Code quality
+npm run format              # Prettier
+npm run lint                # ESLint
+npm run typecheck           # Both node and web
+npm run typecheck:node      # Main/preload only
+npm run typecheck:web       # Renderer only
+
+# Build
+npm run build:win           # Windows installer
+npm run build:mac           # macOS app
+npm run build:linux         # Linux AppImage + deb
+```
+
+## Code Style
+
+- **Prettier**: single quotes, no semicolons, 100-char line width, no trailing commas, 2-space indent
+- **ESLint**: electron-toolkit TypeScript config + Vue plugin, single-word component names allowed
+- **Naming**: camelCase for functions/variables, PascalCase for components/interfaces
+- **IPC channels**: prefixed by domain — `db:`, `fs:`, `debug:`, `models:`
+
+## Key Patterns
+
+- Type-safe IPC via `AxolotlAPI` interface in `src/types.ts`
+- Debounced JSON storage saves (500ms) with atomic writes (temp file → rename)
+- Lazy-loaded Vue route components
+- Backend runs on `http://localhost:8001`
+- ML model files placed in `src/backend/models/` (supports multiple, switchable via UI)
+
+## Backend Setup
+
+1. Python must be installed
+2. Place YOLOv8 `.pt` model file(s) in `src/backend/models/`
+3. Virtual environment created at `src/backend/venv/`
+4. `npm run start-backend` activates venv and starts FastAPI server
+5. App UI allows switching between available models via dropdown on Input page

--- a/axolotlmeasurement/src/backend/directions.md
+++ b/axolotlmeasurement/src/backend/directions.md
@@ -5,7 +5,7 @@ Before getting started:
 Ensure you have python installed on your computer.
 To check, run python --version (or python3 --version). If you have either installed, you'll get the version number.
 
-Next, you need the model. It should be named best.pt. Put it into src/backend.
+Next, you need a model. Place your .pt model file(s) into `src/backend/models/`. You can have multiple models — the app lets you switch between them.
 Now, we can run the app locally.
 
 ## Virtual Environment setup (allows local installation of python packages)

--- a/axolotlmeasurement/src/backend/kp_est_01_results.py
+++ b/axolotlmeasurement/src/backend/kp_est_01_results.py
@@ -3,6 +3,7 @@ import os
 from pathlib import Path
 import sys
 import json
+import argparse
 
 # Get correct path for bundled resources
 # (important for built app working on anyone's OS other than mine lol)
@@ -17,19 +18,17 @@ def resource_path(relative_path):
 
     return os.path.join(base_path, relative_path)
 
-# --- Path Refactoring ---
-model_path = resource_path("best.pt")
+# --- Parse arguments ---
+parser = argparse.ArgumentParser()
+parser.add_argument('--model', default='models/best.pt', help='Path to .pt model file')
+parser.add_argument('images', nargs='+', help='Image file paths')
+args = parser.parse_args()
 
 # --- Initialize YOLO model ---
+model_path = resource_path(args.model)
 model = YOLO(model_path)
 
-# --- Handling Input/Output ---
-if len(sys.argv) < 2:
-    # Print usage instructions to stderr
-    print("Usage: python kp_est_01_results.py <image_path_1> <image_path_2> ...", file=sys.stderr)
-    sys.exit(1)
-
-image_files = [Path(p) for p in sys.argv[1:]]
+image_files = [Path(p) for p in args.images]
 
 # printing to stderr so I don't accidentally read in my program, because of how this file is set up.
 print(f"Found {len(image_files)} images to process...", file=sys.stderr)

--- a/axolotlmeasurement/src/preload/index.ts
+++ b/axolotlmeasurement/src/preload/index.ts
@@ -42,9 +42,12 @@ const api: AxolotlAPI = {
       }
     },
 
-    processImages: async (paths: string[]): Promise<ProcessSuccess | ProcessError> => {
+    processImages: async (
+      paths: string[],
+      model?: string
+    ): Promise<ProcessSuccess | ProcessError> => {
       try {
-        const result: AxoData[] = await ipcRenderer.invoke('process-images', paths)
+        const result: AxoData[] = await ipcRenderer.invoke('process-images', paths, model)
         return { message: 'Images processed successfully', data: result } as ProcessSuccess
       } catch (error) {
         return {
@@ -52,11 +55,18 @@ const api: AxolotlAPI = {
           error: error instanceof Error ? error.message : String(error)
         } as ProcessError
       }
-    }
+    },
+
+    embedPngMetadata: (pngBase64: string, metadata: Record<string, string>): Promise<string> =>
+      ipcRenderer.invoke('fs:embed-png-metadata', pngBase64, metadata)
+  },
+
+  models: {
+    listModels: (): Promise<string[]> => ipcRenderer.invoke('models:list')
   },
 
   downloadAllImages: (
-    files: { name: string; data: string }[]
+    files: { name: string; data: string; metadata?: Record<string, string> }[]
   ): Promise<{ success: boolean; message: string }> =>
     ipcRenderer.invoke('download-all-images', files)
 }

--- a/axolotlmeasurement/src/types.ts
+++ b/axolotlmeasurement/src/types.ts
@@ -5,29 +5,30 @@ export type fileOptions = 'file' | 'folder'
 
 // The fundamental keypoint structure - a labeled point in 2D space
 export interface Keypoint {
-  name: string  // Like "Snout", "Neck", etc.
-  x: number     // X coordinate in pixels (relative to original image size)
-  y: number     // Y coordinate in pixels (relative to original image size)
+  name: string // Like "Snout", "Neck", etc.
+  x: number // X coordinate in pixels (relative to original image size)
+  y: number // Y coordinate in pixels (relative to original image size)
 }
 
 // The main structure for an image in your application
 // Everything lives directly on this object - no nested "data" property
 export interface ImageFile {
-  inputPath: string      // Full file path to the original image
-  outputPath: string     // Where processed image should be saved (if needed)
-  name: string           // Just the filename, like "axolotl_001.jpg"
-  processed: boolean     // Has the ML model run on this image?
-  verified: boolean      // Has the user confirmed the keypoints are correct?
-  keypoints: Keypoint[]  // The keypoint data - always present, empty array if none
-  boundingBox: number[]  // Bounding box coordinates [x1, y1, x2, y2] - empty if none
+  inputPath: string // Full file path to the original image
+  outputPath: string // Where processed image should be saved (if needed)
+  name: string // Just the filename, like "axolotl_001.jpg"
+  processed: boolean // Has the ML model run on this image?
+  verified: boolean // Has the user confirmed the keypoints are correct?
+  keypoints: Keypoint[] // The keypoint data - always present, empty array if none
+  boundingBox: number[] // Bounding box coordinates [x1, y1, x2, y2] - empty if none
+  modelName: string // Which .pt model was used to process this image
 }
 
 // This interface describes what the Python backend returns
 // It exists ONLY to type the backend response - you'll convert it to ImageFile immediately
 export interface AxoData {
-  image_name: string      // Matches ImageFile.name
-  bounding_box: number[]  // Gets converted to ImageFile.boundingBox
-  keypoints: Keypoint[] | number[][]  // Backend might return nested arrays, we normalize this
+  image_name: string // Matches ImageFile.name
+  bounding_box: number[] // Gets converted to ImageFile.boundingBox
+  keypoints: Keypoint[] | number[][] // Backend might return nested arrays, we normalize this
 }
 
 // Used to specify which images to delete in bulk operations
@@ -44,12 +45,13 @@ export interface ImageUpdateData {
   verified?: boolean
   keypoints?: Keypoint[]
   boundingBox?: number[]
+  modelName?: string
 }
 
 // The successful response from image processing
 export interface ProcessSuccess {
   message: string
-  data: AxoData[]  // Array of results from the backend
+  data: AxoData[] // Array of results from the backend
 }
 
 // The error response from image processing
@@ -81,18 +83,24 @@ export interface AxolotlAPI {
     readFile: (filePath: string, encoding?: BufferEncoding) => Promise<string | Buffer>
     writeFile: (filePath: string, data: string | Buffer) => Promise<void>
     readFolder: (filePaths: string[], encoding?: BufferEncoding) => Promise<string[] | Buffer[]>
-    processImages: (paths: string[]) => Promise<ProcessSuccess | ProcessError>
+    processImages: (paths: string[], model?: string) => Promise<ProcessSuccess | ProcessError>
+    embedPngMetadata: (pngBase64: string, metadata: Record<string, string>) => Promise<string>
+  }
+
+  // Model operations
+  models: {
+    listModels: () => Promise<string[]>
   }
 
   // Batch download functionality
   downloadAllImages: (
-    files: { name: string; data: string }[]
+    files: { name: string; data: string; metadata?: Record<string, string> }[]
   ) => Promise<{ success: boolean; message: string }>
 }
 
 // Structure of your JSON database file
 export interface ImageDatabase {
-  version: number  // For future migrations if you change the structure
+  version: number // For future migrations if you change the structure
   images: ImageFile[]
   metadata: {
     lastModified: string


### PR DESCRIPTION
Allow users to switch between multiple YOLO .pt model files via a dropdown on the Input page. Track which model processed each image, render the model name as text on exported images (bottom-left), and embed it as PNG tEXt metadata for programmatic access.