### PR TITLE
Add 6-keypoint model support, measurements display, and open models f…

### DIFF
--- a/axolotlmeasurement/src/main/index.ts
+++ b/axolotlmeasurement/src/main/index.ts
@@ -177,6 +177,21 @@ app.whenReady().then(async () => {
     }
   })
 
+  ipcMain.handle('models:open-folder', async () => {
+    // In dev, models live next to the Python backend source
+    // In production, they live next to the bundled server executable
+    const modelsPath = is.dev
+      ? join(__dirname, '../../backend/models')
+      : join(process.resourcesPath, 'resources', 'axolotl-server', 'models')
+
+    // Create the folder if it doesn't exist yet so the user can see it
+    if (!fs.existsSync(modelsPath)) {
+      fs.mkdirSync(modelsPath, { recursive: true })
+    }
+
+    await shell.openPath(modelsPath)
+  })
+
   ipcMain.handle(
     'fs:embed-png-metadata',
     async (_: unknown, pngBase64: string, metadata: Record<string, string>) => {

--- a/axolotlmeasurement/src/preload/index.ts
+++ b/axolotlmeasurement/src/preload/index.ts
@@ -62,7 +62,8 @@ const api: AxolotlAPI = {
   },
 
   models: {
-    listModels: (): Promise<string[]> => ipcRenderer.invoke('models:list')
+    listModels: (): Promise<string[]> => ipcRenderer.invoke('models:list'),
+    openModelsFolder: (): Promise<void> => ipcRenderer.invoke('models:open-folder')
   },
 
   downloadAllImages: (

--- a/axolotlmeasurement/src/renderer/src/views/GalleryView.vue
+++ b/axolotlmeasurement/src/renderer/src/views/GalleryView.vue
@@ -57,6 +57,22 @@
         Model: {{ selectedImage.modelName }}
       </div>
 
+      <div v-if="selectedImage?.measurements" class="glass-panel pd1 measurements-panel">
+        <span class="measurements-title txt-col">Measurements (px)</span>
+        <div class="measurements-grid">
+          <span class="txt-col">SVL (total)</span>
+          <span class="measurement-value">{{ selectedImage.measurements.total_length.toFixed(1) }}</span>
+          <span class="txt-col">Head → midU</span>
+          <span class="measurement-value">{{ selectedImage.measurements.head_to_midU.toFixed(1) }}</span>
+          <span class="txt-col">midU → midL</span>
+          <span class="measurement-value">{{ selectedImage.measurements.midU_to_midL.toFixed(1) }}</span>
+          <span class="txt-col">midL → legs</span>
+          <span class="measurement-value">{{ selectedImage.measurements.midL_to_legs_midpoint.toFixed(1) }}</span>
+          <span class="txt-col">legs → Tail</span>
+          <span class="measurement-value">{{ selectedImage.measurements.legs_midpoint_to_tail.toFixed(1) }}</span>
+        </div>
+      </div>
+
       <div class="glass-panel pd1 flx gp1 jc-end">
         <button class="discreet-btn flx gp05 al-c" @click="copyData(selectedImage)">
           <span class="material-icons-outlined">content_copy</span>
@@ -452,5 +468,31 @@ onMounted(() => {
   padding: var(--sp1);
   background-color: var(--bg-col);
   border-radius: var(--br);
+}
+
+.measurements-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.measurements-title {
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  opacity: 0.9;
+}
+
+.measurements-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.2rem 1rem;
+  font-size: var(--fs-sm);
+}
+
+.measurement-value {
+  color: var(--txt-col);
+  opacity: 0.8;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 </style>

--- a/axolotlmeasurement/src/renderer/src/views/InputView.vue
+++ b/axolotlmeasurement/src/renderer/src/views/InputView.vue
@@ -22,6 +22,13 @@
         >
           <span class="material-icons-outlined icon">refresh</span>
         </button>
+        <button
+          class="discreet-btn flx al-c"
+          title="Open models folder"
+          @click="openModelsFolder"
+        >
+          <span class="material-icons-outlined icon">folder_open</span>
+        </button>
       </div>
       <div class="draganddrop glass-panel flx col al-c gp1 pd2">
         <span>Drag and drop images/folders here (WIP)</span>
@@ -77,6 +84,14 @@
         @click="imageStore.loadModels()"
       >
         <span class="material-icons-outlined icon">refresh</span>
+      </button>
+      <button
+        class="discreet-btn flx al-c"
+        title="Open models folder"
+        :disabled="isLoading"
+        @click="openModelsFolder"
+      >
+        <span class="material-icons-outlined icon">folder_open</span>
       </button>
     </div>
 
@@ -191,6 +206,10 @@ function clearInput(): void {
   failedFileCount.value = 0
   isLoading.value = false
   imageStore.clearAllInputImages() // selectedToProcess is reset by imageStore function
+}
+
+async function openModelsFolder(): Promise<void> {
+  await window.api.models.openModelsFolder()
 }
 
 async function removeFile(path: string): Promise<void> {

--- a/axolotlmeasurement/src/types.ts
+++ b/axolotlmeasurement/src/types.ts
@@ -5,9 +5,18 @@ export type fileOptions = 'file' | 'folder'
 
 // The fundamental keypoint structure - a labeled point in 2D space
 export interface Keypoint {
-  name: string // Like "Snout", "Neck", etc.
+  name: string // Like "Head", "midU", "legs_midpoint", "Tail"
   x: number // X coordinate in pixels (relative to original image size)
   y: number // Y coordinate in pixels (relative to original image size)
+}
+
+// Computed length measurements from the 6-keypoint model
+export interface Measurements {
+  head_to_midU: number
+  midU_to_midL: number
+  midL_to_legs_midpoint: number
+  legs_midpoint_to_tail: number
+  total_length: number // SVL (snout-vent length proxy)
 }
 
 // The main structure for an image in your application
@@ -21,6 +30,7 @@ export interface ImageFile {
   keypoints: Keypoint[] // The keypoint data - always present, empty array if none
   boundingBox: number[] // Bounding box coordinates [x1, y1, x2, y2] - empty if none
   modelName: string // Which .pt model was used to process this image
+  measurements?: Measurements // Named segment lengths from 6-keypoint model
 }
 
 // This interface describes what the Python backend returns
@@ -28,7 +38,8 @@ export interface ImageFile {
 export interface AxoData {
   image_name: string // Matches ImageFile.name
   bounding_box: number[] // Gets converted to ImageFile.boundingBox
-  keypoints: Keypoint[] | number[][] // Backend might return nested arrays, we normalize this
+  keypoints: Keypoint[] | number[][] // Backend returns named keypoints or raw arrays
+  measurements?: Measurements // Named segment lengths (present when 6-keypoint model used)
 }
 
 // Used to specify which images to delete in bulk operations
@@ -46,6 +57,7 @@ export interface ImageUpdateData {
   keypoints?: Keypoint[]
   boundingBox?: number[]
   modelName?: string
+  measurements?: Measurements
 }
 
 // The successful response from image processing
@@ -90,6 +102,7 @@ export interface AxolotlAPI {
   // Model operations
   models: {
     listModels: () => Promise<string[]>
+    openModelsFolder: () => Promise<void>
   }
 
   // Batch download functionality


### PR DESCRIPTION
…older button

- Backend now parses 6-keypoint model output (Tail, Head, midU, midL, leg1, leg2), computes legs_midpoint, and returns 5 named display keypoints + segment lengths
- New Measurements interface stores SVL and 4 named segment distances per image
- Added 'Open Models Folder' button (folder_open icon) next to model selector on InputView, opening the models directory in the OS file explorer
- GalleryView shows a measurements panel with SVL and segment lengths for images processed by the 6-keypoint model
- IPC plumbing: models:open-folder handler in main, exposed via preload