### PR TITLE
Fix image loading and InputView layout overflow

### DIFF
--- a/axolotlmeasurement/src/renderer/src/components/KeypointDisplay.vue
+++ b/axolotlmeasurement/src/renderer/src/components/KeypointDisplay.vue
@@ -2,7 +2,7 @@
   <div class="keypoint-container">
     <img
       ref="imageRef"
-      :src="imageSrc"
+      :src="safeImageSrc"
       alt="Keypoint image"
       class="display-image"
       @load="updateImageDimensions"
@@ -29,6 +29,18 @@ const props = defineProps<{
   keypoints?: Keypoint[]
   isEditable?: boolean // enable/disable editing
 }>()
+
+// Convert a raw local file path to our custom protocol URL so Electron serves
+// it correctly, even when the path contains spaces or special characters.
+const safeImageSrc = computed(() => {
+  const src = props.imageSrc
+  if (!src) return ''
+  // Already a data URL or custom protocol — pass through unchanged
+  if (src.startsWith('data:') || src.startsWith('axolotl-file://')) return src
+  // Convert Windows backslashes, then percent-encode the path component only
+  const normalized = src.replace(/\\/g, '/')
+  return 'axolotl-file://' + normalized.split('/').map(encodeURIComponent).join('/')
+})
 
 const emit = defineEmits(['update:keypoints']) // Define the event we will emit
 

--- a/axolotlmeasurement/src/renderer/src/views/InputView.vue
+++ b/axolotlmeasurement/src/renderer/src/views/InputView.vue
@@ -47,7 +47,7 @@
     </div>
   </div>
 
-  <div v-else class="flx col al-c gp1 w-full pd1 pt2">
+  <div v-else class="flx col al-c gp1 w-full pd1 pt2 input-active-container">
     <div class="flx al-c jc-sb w-full">
       <h3 class="txt-col">{{ prepText }}</h3>
       <div class="flx gp1">
@@ -99,7 +99,7 @@
       <span class="material-symbols-outlined loading icon">progress_activity</span>
     </div>
 
-    <div v-else class="flx col pd1 w-full selection-container br jc-sb gp05">
+    <div v-else class="flx col pd1 w-full selection-container br gp05">
       <!-- check w/ calvin about making gap between list items smaller -->
       <TransitionGroup name="list">
         <div v-for="image in imagesToProcess" :key="image.inputPath" class="glass-list-item">
@@ -257,13 +257,16 @@ async function startProcessing(): Promise<void> {
   border: 1px dashed var(--bg-col-alt);
 }
 
+.input-active-container {
+  height: calc(100vh - 120px); /* full available height minus header */
+}
+
 .selection-container {
-  max-height: 50vh;
-  overflow-y: scroll;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
   scrollbar-gutter: stable;
-  scrollbar-track-color: none;
   color: var(--txt-col);
-  /* background-color: var(--bg-col-alt); */
 }
 
 .closebtn {


### PR DESCRIPTION
- Register axolotl-file:// custom protocol in main process so local image paths (including those with spaces and special chars) load reliably in the renderer without ERR_FILE_NOT_FOUND errors
- KeypointDisplay converts raw file paths to axolotl-file:// URLs via a computed safeImageSrc; data: URLs and already-converted URLs pass through
- InputView: give the active state a fixed viewport height and let the file list grow/shrink via flex to fill remaining space, so the Start button is always visible regardless of how many images are selected