### PR TITLE
Fix layout overflow: use proper flex height chain instead of hardcode…

### DIFF
--- a/axolotlmeasurement/src/renderer/src/App.vue
+++ b/axolotlmeasurement/src/renderer/src/App.vue
@@ -12,7 +12,17 @@ onMounted(async () => {
 
 <template>
   <Header></Header>
-  <RouterView />
+  <div class="router-view-wrapper">
+    <RouterView />
+  </div>
 </template>
 
-<style></style>
+<style>
+.router-view-wrapper {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+</style>

--- a/axolotlmeasurement/src/renderer/src/assets/base.css
+++ b/axolotlmeasurement/src/renderer/src/assets/base.css
@@ -38,6 +38,11 @@ body,
   overflow: hidden; /* prevent the whole app from scrolling */
 }
 
+#app {
+  display: flex;
+  flex-direction: column;
+}
+
 body {
   margin: 0;
   padding: var(--sp2) var(--sp2) var(--sp1) var(--sp2);

--- a/axolotlmeasurement/src/renderer/src/views/InputView.vue
+++ b/axolotlmeasurement/src/renderer/src/views/InputView.vue
@@ -258,7 +258,7 @@ async function startProcessing(): Promise<void> {
 }
 
 .input-active-container {
-  height: calc(100vh - 120px); /* full available height minus header */
+  height: 100%; /* fill the router-view-wrapper flex child */
 }
 
 .selection-container {


### PR DESCRIPTION
…d calc

- Make #app a flex column so Header and RouterView stack correctly
- Wrap RouterView in a flex-growing div (router-view-wrapper) so views always fill the remaining space below the header
- InputView active container now uses height: 100% relative to its flex parent, eliminating the hardcoded calc(100vh - 120px) guess that was clipping the bottom buttons